### PR TITLE
[feat, fix] #151 Open API 타임아웃 및 요청 재시도 로직 구현

### DIFF
--- a/src/main/java/com/book/backend/domain/openapi/service/OpenAPI.java
+++ b/src/main/java/com/book/backend/domain/openapi/service/OpenAPI.java
@@ -89,9 +89,15 @@ public class OpenAPI {
     private JSONObject readStreamToJson(InputStreamReader streamResponse, OpenAPIResponseInterface responseDto) throws Exception {
         log.trace("OpenAPI > readStreamToJson()");
         String fullResponse = new BufferedReader(streamResponse).readLine();
+        JSONObject jsonObject;
 
         // response JSON 파싱
-        JSONObject jsonObject = (JSONObject) (new JSONParser()).parse(fullResponse);
+        try {
+            jsonObject = (JSONObject) (new JSONParser()).parse(fullResponse);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INVALID_OPENAPI_RESPONSE);
+        }
+
         JSONObject response = (JSONObject) jsonObject.get("response");
 
         // API 일일 호출 횟수 초과 에러 (일 최대 500건)

--- a/src/main/java/com/book/backend/domain/openapi/service/OpenAPI.java
+++ b/src/main/java/com/book/backend/domain/openapi/service/OpenAPI.java
@@ -45,6 +45,9 @@ public class OpenAPI {
                 CompletableFuture<JSONObject> future = CompletableFuture.supplyAsync(() -> {
                     try {
                         URL url = setRequest(subUrl, dto); // 요청 만들기
+
+                        log.trace("Request URL: " + url);
+
                         InputStreamReader streamResponse = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8); // 요청 보내기
                         return readStreamToJson(streamResponse, responseDto); // 응답 stream 을 json 으로 변환
                     } catch (Exception e) {

--- a/src/main/java/com/book/backend/exception/ErrorCode.java
+++ b/src/main/java/com/book/backend/exception/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
 
     // 외부 API 에러
     KAKAO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "카카오 서버에 오류가 발생했습니다."),
+    INVALID_OPENAPI_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "500", "OPEN API 서버에서 잘못된 응답을 전송했습니다."),
     API_CALL_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "429", "OPEN API 일일 호출 횟수를 초과했습니다. (일 최대 500건)"),
     LIBCODE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "존재하는 도서관 코드인지 확인해주세요."),
     OPENAPI_REQUEST_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "408", "OPEN API 응답을 요청하는 중 타임아웃이 발생했습니다."),

--- a/src/main/java/com/book/backend/exception/ErrorCode.java
+++ b/src/main/java/com/book/backend/exception/ErrorCode.java
@@ -52,10 +52,12 @@ public enum ErrorCode {
     MESSAGE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "500", "메시지 저장에 실패했습니다."),
     USER_OPENTALK_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "해당 오픈톡은 유저의 즐겨찾기 리스트에 없습니다."),
     INVALID_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "400", "text, image, goal 중 하나를 입력해주세요."),
+
     // 외부 API 에러
     KAKAO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "카카오 서버에 오류가 발생했습니다."),
     API_CALL_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "429", "OPEN API 일일 호출 횟수를 초과했습니다. (일 최대 500건)"),
     LIBCODE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "존재하는 도서관 코드인지 확인해주세요."),
+    OPENAPI_REQUEST_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "408", "OPEN API 응답을 요청하는 중 타임아웃이 발생했습니다."),
 
     // OAuth2
     HEADER_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "Header 파싱 중 에러가 발생했습니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,8 @@ spring-doc:
 openapi:
   url: ${OPENAPI_URL}
   authKey: ${OPENAPI_AUTH_KEY}
+  timeoutSeconds: ${OPENAPI_TIMEOUT_SECONDS}
+  maxRetryCounts: ${OPENAPI_MAX_RETRY_COUNTS}
 
 kakao:
   publicKeyUri: https://kauth.kakao.com/.well-known/jwks.json


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- [x] #151 


## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- [x] Open API 타임아웃 및 요청 재시도 로직 구현
- [x] Open API 요청 URL 로깅 추가
- [x] Open API 응답 파싱이 불가한 경우에 대한 예외처리 추가


### 스크린샷 (선택)
<img width="1302" alt="image" src="https://github.com/user-attachments/assets/42ab9bc4-c91f-4354-b24b-82f2f4fa4319">

이제 Open API 요청 중 타임아웃이 발생하면 위와 같이 재요청을 시도합니다.

## 💬 리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 최근 API를 호출할 경우 API 호출을 시작한 초기에 응답 지연(1분 이상)과 함께 JSON 응답이 아닌 HTML 응답이 오는 것을 확인했습니다.
> 
> 따라서 현재 로직상으로는 Open API를 처음 한번만 호출하기 때문에, 이 때 응답 지연 및 HTML 응답이 발생할 경우 강제로 Refresh하지 않는 이상 정상적으로 클라이언트에게 값이 반환되지 않습니다. (이러한 이유로 현재 앱에 접속하면 책 목록들이 나타나지 않는 현상이 있습니다.)
> 
> 이를 해결하기 위해, Java의 `CompletableFuture`와 `ExecutorService`를 활용하여 비동기적으로 Open API 요청을 처리하고, 응답 시간 초과(타임아웃) 시 정상적인 응답이 올 때까지 다시 요청을 보내도록 설정했습니다.
>
> `.env` 파일의 `#openApi` 부분이 변경되었으니, 노션 참고하여 **서버 측 파일 수정** 부탁드리겠습니다.


