### PR TITLE
[Enhancement] #153 책 추천 API 응답 속도 개선

### DIFF
--- a/src/main/java/com/book/backend/domain/book/controller/BookController.java
+++ b/src/main/java/com/book/backend/domain/book/controller/BookController.java
@@ -59,8 +59,8 @@ public class BookController {
 
         HashSet<String> duplicateCheckSet = new HashSet<>();
         LinkedList<RecommendListResponseDto> duplicateRemovedList = bookService.duplicateChecker(response, duplicateCheckSet);
-        bookService.ensureRecommendationsCount(duplicateRemovedList, duplicateCheckSet);
         response = RandomPicker.randomPick(duplicateRemovedList, 10); // 10개 랜덤 추출
+
         return responseTemplate.success(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/book/backend/domain/book/service/BookService.java
+++ b/src/main/java/com/book/backend/domain/book/service/BookService.java
@@ -46,22 +46,6 @@ public class BookService {
         return responseList;
     }
 
-    /* 추천 책 수가 10보다 작으면 추천된 isbn 으로 recommend() 다시 호출 */
-    public void ensureRecommendationsCount(LinkedList<RecommendListResponseDto> list, HashSet<String> set) throws Exception {
-        log.trace("BookService > ensureRecommendationsCount()");
-        LinkedList<RecommendListResponseDto> originalList = new LinkedList<>(list);
-        Iterator<RecommendListResponseDto> iterator = originalList.iterator();
-        while (originalList.size() < 10 && iterator.hasNext()) {
-            RecommendListRequestDto newRequestDto =  RecommendListRequestDto.builder().isbn13(iterator.next().getIsbn13()).build(); // 추천된 다른 책의 isbn13
-            LinkedList<RecommendListResponseDto> newRecommendList = recommend(newRequestDto);
-            // 기존에 추가된 책인지 확인
-            for(RecommendListResponseDto dto : newRecommendList){
-                String key = dto.getBookname() + dto.getAuthors();
-                if(set.add(key)) list.add(dto);
-            }
-        }
-    }
-
     public LinkedList<RecommendListResponseDto> duplicateChecker(LinkedList<RecommendListResponseDto> list, HashSet<String> set){
         log.trace("BookService > duplicateChecker()");
         LinkedList<RecommendListResponseDto> duplicateRemovedList = new LinkedList<>();

--- a/src/main/java/com/book/backend/domain/openapi/service/OpenAPI.java
+++ b/src/main/java/com/book/backend/domain/openapi/service/OpenAPI.java
@@ -89,9 +89,15 @@ public class OpenAPI {
     private JSONObject readStreamToJson(InputStreamReader streamResponse, OpenAPIResponseInterface responseDto) throws Exception {
         log.trace("OpenAPI > readStreamToJson()");
         String fullResponse = new BufferedReader(streamResponse).readLine();
+        JSONObject jsonObject;
 
         // response JSON 파싱
-        JSONObject jsonObject = (JSONObject) (new JSONParser()).parse(fullResponse);
+        try {
+            jsonObject = (JSONObject) (new JSONParser()).parse(fullResponse);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INVALID_OPENAPI_RESPONSE);
+        }
+
         JSONObject response = (JSONObject) jsonObject.get("response");
 
         // API 일일 호출 횟수 초과 에러 (일 최대 500건)

--- a/src/main/java/com/book/backend/domain/openapi/service/OpenAPI.java
+++ b/src/main/java/com/book/backend/domain/openapi/service/OpenAPI.java
@@ -45,6 +45,9 @@ public class OpenAPI {
                 CompletableFuture<JSONObject> future = CompletableFuture.supplyAsync(() -> {
                     try {
                         URL url = setRequest(subUrl, dto); // 요청 만들기
+
+                        log.trace("Request URL: " + url);
+
                         InputStreamReader streamResponse = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8); // 요청 보내기
                         return readStreamToJson(streamResponse, responseDto); // 응답 stream 을 json 으로 변환
                     } catch (Exception e) {

--- a/src/main/java/com/book/backend/exception/ErrorCode.java
+++ b/src/main/java/com/book/backend/exception/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
 
     // 외부 API 에러
     KAKAO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "카카오 서버에 오류가 발생했습니다."),
+    INVALID_OPENAPI_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "500", "OPEN API 서버에서 잘못된 응답을 전송했습니다."),
     API_CALL_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "429", "OPEN API 일일 호출 횟수를 초과했습니다. (일 최대 500건)"),
     LIBCODE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "존재하는 도서관 코드인지 확인해주세요."),
     OPENAPI_REQUEST_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "408", "OPEN API 응답을 요청하는 중 타임아웃이 발생했습니다."),

--- a/src/main/java/com/book/backend/exception/ErrorCode.java
+++ b/src/main/java/com/book/backend/exception/ErrorCode.java
@@ -52,10 +52,12 @@ public enum ErrorCode {
     MESSAGE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "500", "메시지 저장에 실패했습니다."),
     USER_OPENTALK_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "해당 오픈톡은 유저의 즐겨찾기 리스트에 없습니다."),
     INVALID_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "400", "text, image, goal 중 하나를 입력해주세요."),
+
     // 외부 API 에러
     KAKAO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "카카오 서버에 오류가 발생했습니다."),
     API_CALL_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "429", "OPEN API 일일 호출 횟수를 초과했습니다. (일 최대 500건)"),
     LIBCODE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "존재하는 도서관 코드인지 확인해주세요."),
+    OPENAPI_REQUEST_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "408", "OPEN API 응답을 요청하는 중 타임아웃이 발생했습니다."),
 
     // OAuth2
     HEADER_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "Header 파싱 중 에러가 발생했습니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,8 @@ spring-doc:
 openapi:
   url: ${OPENAPI_URL}
   authKey: ${OPENAPI_AUTH_KEY}
+  timeoutSeconds: ${OPENAPI_TIMEOUT_SECONDS}
+  maxRetryCounts: ${OPENAPI_MAX_RETRY_COUNTS}
 
 kakao:
   publicKeyUri: https://kauth.kakao.com/.well-known/jwks.json


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- [x] #153 


## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- [x] `ensureRecommendataionsCount` 메서드 제거하여 API 응답 속도 개선


### 스크린샷 (선택)
- 응답 속도 개선 전 -> `4.479 sec`
<img width="1335" alt="image" src="https://github.com/user-attachments/assets/df1c1df6-3d20-47e8-bee8-09336a47a236">

<br>

- 응답 속도 개선 후 -> `0.823 sec`
<img width="1335" alt="image" src="https://github.com/user-attachments/assets/e102c301-f3dd-4edf-8de7-0ab329f2538a">


## 💬 리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

> 먼저 **[이전 PR](https://github.com/BOOK-TALK/Readables-Server/pull/152) 승인** 후 확인해주시면 감사드리겠습니다.
> 
> `ensureRecommendationsCount` 메서드를 제거함으로써 응답 속도를 개선했습니다.
>
> `ensureRecommendationsCount`를 제거해야 하는 이유는 다음과 같습니다.
> 
> 1. 반환값이 10개보다 적을 때 Open API 호출 횟수가 많아지므로 **응답 지연**이 유발됩니다.
>    - 기본 응답 개수가 5개일 때, `ensureRecommendationsCount` 로직을 거치지 않으면 Open API Request를 총 **2번** 호출합니다. (mania, reader)
>    - 그러나 `ensureRecommendationsCount` 로직을 거치는 경우 Open API Request를 총 **12번** 호출합니다. (응답된 개수마다 2번씩 추가로 호출하므로)
>
> 2. 메서드를 통해 창출되는 이득, 즉 **반환값 증가량이 적습니다**.
>    - `9788983927620` isbn 코드로 테스트했을 때, `ensureRecommendationsCount` 로직을 거치지 않는 경우 반환값이 **5개**입니다.
>    - 그리고 `ensureRecommendationsCount` 로직을 거치는 경우 반환값이 **7개**입니다. 즉 단 **2개**밖에 증가하지 않습니다.
>
> 즉 메서드로 인한 이득과 성능 이슈가 Trade-off 관계에 있지만, 메서드로 인한 이득이 크지 않음을 고려하면 성능을 위해 **해당 메서드를 제거**하는 것이 맞을 것 같다고 생각합니다.
> 다른 의견이 있으시다면 코멘트 달아주시면 감사하겠습니다.
