### PR TITLE
[refactor] #156 타임아웃 시간 .env에서 삭제, 커스텀 가능하게 개선

### DIFF
--- a/src/main/java/com/book/backend/domain/book/service/BookService.java
+++ b/src/main/java/com/book/backend/domain/book/service/BookService.java
@@ -34,12 +34,12 @@ public class BookService {
         LinkedList<RecommendListResponseDto> responseList = new LinkedList<>();
 
         requestDto.setType("mania");
-        JSONObject maniaJsonResponse = openAPI.connect(subUrl, requestDto, new RecommendListResponseDto());
+        JSONObject maniaJsonResponse = openAPI.connect(subUrl, requestDto, new RecommendListResponseDto(), 1);
         ResponseParser maniaResponseParser = new ResponseParser();
         responseList.addAll(maniaResponseParser.recommend(maniaJsonResponse));
 
         requestDto.setType("reader");
-        JSONObject readerJsonResponse = openAPI.connect(subUrl, requestDto, new RecommendListResponseDto());
+        JSONObject readerJsonResponse = openAPI.connect(subUrl, requestDto, new RecommendListResponseDto(), 1);
         ResponseParser readerResponseParser = new ResponseParser();
         responseList.addAll(readerResponseParser.recommend(readerJsonResponse));
 
@@ -59,7 +59,7 @@ public class BookService {
     public LinkedList<HotTrendResponseDto> hotTrend(HotTrendRequestDto requestDto) throws Exception{
         log.trace("BookService > hotTrend()");
         String subUrl = "hotTrend";
-        JSONObject jsonResponse = openAPI.connect(subUrl, requestDto, new HotTrendResponseDto());
+        JSONObject jsonResponse = openAPI.connect(subUrl, requestDto, new HotTrendResponseDto(), 1);
         ResponseParser responseParser = new ResponseParser();
         return responseParser.hotTrend(jsonResponse);
     }
@@ -67,7 +67,7 @@ public class BookService {
     public LinkedList<MonthlyKeywordsResponseDto> keywords(MonthlyKeywordsRequestDto requestDto) throws Exception{
         log.trace("BookService > keywords()");
         String subUrl = "monthlyKeywords";
-        JSONObject jsonResponse = openAPI.connect(subUrl, requestDto, new MonthlyKeywordsResponseDto());
+        JSONObject jsonResponse = openAPI.connect(subUrl, requestDto, new MonthlyKeywordsResponseDto(), 1);
         ResponseParser responseParser = new ResponseParser();
         return responseParser.keywords(jsonResponse);
     }
@@ -76,7 +76,7 @@ public class BookService {
         log.trace("BookService > customHotTrend()");
         String subUrl = "loanItemSrch";
         requestDto.setPageSize("25");
-        JSONObject jsonResponse = openAPI.connect(subUrl, requestDto, new LoanItemSrchResponseDto());
+        JSONObject jsonResponse = openAPI.connect(subUrl, requestDto, new LoanItemSrchResponseDto(), 1);
         ResponseParser responseParser = new ResponseParser();
         LinkedList<LoanItemSrchResponseDto> responseList = responseParser.loanItemSrch(jsonResponse);
         return responseParser.customPageFilter(responseList, "1", "10");

--- a/src/main/java/com/book/backend/domain/detail/service/DetailService.java
+++ b/src/main/java/com/book/backend/domain/detail/service/DetailService.java
@@ -37,7 +37,7 @@ public class DetailService {
     public DetailResponseDto detail(DetailRequestDto requestDto) throws Exception {
         log.trace("DetailService > detail()");
         String subUrl = "usageAnalysisList";
-        JSONObject jsonResponse = openAPI.connect(subUrl, requestDto, new SearchResponseDto());
+        JSONObject jsonResponse = openAPI.connect(subUrl, requestDto, new SearchResponseDto(), 1);
         ResponseParser responseParser = new ResponseParser();
         return responseParser.detail(jsonResponse);
     }
@@ -58,7 +58,7 @@ public class DetailService {
                             .isbn13(isbn).build();
 
                     String subUrl = "bookExist";
-                    JSONObject jsonResponse = openAPI.connect(subUrl, bookExistRequestDto, new BookExistResponseDto());
+                    JSONObject jsonResponse = openAPI.connect(subUrl, bookExistRequestDto, new BookExistResponseDto(), 1);
                     ResponseParser responseParser = new ResponseParser();
                     boolean isLoanable = responseParser.loanAvailable(jsonResponse);
 

--- a/src/main/java/com/book/backend/domain/genre/service/GenreService.java
+++ b/src/main/java/com/book/backend/domain/genre/service/GenreService.java
@@ -83,11 +83,11 @@ public class GenreService {
 
         String subUrl = "loanItemSrch";
 
-        requestDto.setPageSize("500");  // 커스텀 페이지네이션 적용하기 전 페이지 크기 설정
+        requestDto.setPageSize("300");  // 커스텀 페이지네이션 적용하기 전 페이지 크기 설정
         requestDto.setStartDt(startDt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
         requestDto.setEndDt(endDt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
 
-        JSONObject JsonResponse = openAPI.connect(subUrl, requestDto, new LoanItemSrchResponseDto());
+        JSONObject JsonResponse = openAPI.connect(subUrl, requestDto, new LoanItemSrchResponseDto(), 1);
         return new LinkedList<>(genreResponseParser.periodTrend(JsonResponse, filteredPageNo, filteredPageSize));
     }
 
@@ -96,9 +96,9 @@ public class GenreService {
 
         String subUrl = "loanItemSrch";
 
-        requestDto.setPageSize("500");  // 셔플할 리스트의 페이지 크기 설정
+        requestDto.setPageSize("300");  // 셔플할 리스트의 페이지 크기 설정
 
-        JSONObject JsonResponse = openAPI.connect(subUrl, requestDto, new LoanItemSrchResponseDto());
+        JSONObject JsonResponse = openAPI.connect(subUrl, requestDto, new LoanItemSrchResponseDto(), 1);
 
         return new LinkedList<>(genreResponseParser.random(JsonResponse, maxSize));
     }
@@ -109,11 +109,11 @@ public class GenreService {
 
         String subUrl = "loanItemSrch";
 
-        requestDto.setPageSize("1500");  // 커스텀 페이지네이션 적용하기 전 페이지 크기 설정
+        requestDto.setPageSize("1200");  // 커스텀 페이지네이션 적용하기 전 페이지 크기 설정
         LocalDate today = LocalDate.now();
         int currentYear = Integer.parseInt(today.format(DateTimeFormatter.ofPattern("yyyy")));
 
-        JSONObject JsonResponse = openAPI.connect(subUrl, requestDto, new LoanItemSrchResponseDto());
+        JSONObject JsonResponse = openAPI.connect(subUrl, requestDto, new LoanItemSrchResponseDto(), 2);
 
         return new LinkedList<>(genreResponseParser.newTrend(JsonResponse, currentYear, filteredPageNo, filteredPageSize));
     }

--- a/src/main/java/com/book/backend/domain/goal/mapper/GoalMapper.java
+++ b/src/main/java/com/book/backend/domain/goal/mapper/GoalMapper.java
@@ -68,7 +68,7 @@ public class GoalMapper {
         String subUrl = "usageAnalysisList";
         DetailRequestDto requestDto = new DetailRequestDto(isbn);
 
-        JSONObject jsonResponse = openAPI.connect(subUrl, requestDto, new SearchResponseDto());
+        JSONObject jsonResponse = openAPI.connect(subUrl, requestDto, new SearchResponseDto(), 1);
         BookInfoDto bookInfo = responseParser.getBookInfo(jsonResponse);
 
         return bookMapper.convertToBookSummaryDto(bookInfo);

--- a/src/main/java/com/book/backend/domain/library/service/LibraryService.java
+++ b/src/main/java/com/book/backend/domain/library/service/LibraryService.java
@@ -24,7 +24,7 @@ public class LibraryService {
         log.trace("LibraryService > searchLibraries()");
 
         String subUrl = "libSrch";
-        JSONObject JsonResponse = openAPI.connect(subUrl, requestDto, new LibSrchResponseDto());
+        JSONObject JsonResponse = openAPI.connect(subUrl, requestDto, new LibSrchResponseDto(), 1);
 
         return new LinkedList<>(responseParser.libSrch(JsonResponse));
     }

--- a/src/main/java/com/book/backend/domain/openapi/service/OpenAPI.java
+++ b/src/main/java/com/book/backend/domain/openapi/service/OpenAPI.java
@@ -27,16 +27,13 @@ public class OpenAPI {
     @Value("${openapi.authKey}")
     private String authKey;
 
-    @Value("${openapi.timeoutSeconds}")
-    private int TIMEOUT_SECONDS;  // 타임아웃 시간 (초)
-
     @Value("${openapi.maxRetryCounts}")
     private int MAX_RETRY_COUNTS;  // 최대 재시도 횟수
 
     private final String format = "json";
     private final ExecutorService executorService = Executors.newCachedThreadPool();
 
-    public JSONObject connect(String subUrl, OpenAPIRequestInterface dto, OpenAPIResponseInterface responseDto) throws Exception {
+    public JSONObject connect(String subUrl, OpenAPIRequestInterface dto, OpenAPIResponseInterface responseDto, int timeoutSeconds) throws Exception {
         log.trace("OpenAPI > connect()");
         int retryCount = 0;
 
@@ -56,7 +53,7 @@ public class OpenAPI {
                 }, executorService);
 
                 // 타임아웃 설정 및 결과 가져오기
-                return future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                return future.get(timeoutSeconds, TimeUnit.SECONDS);
             } catch (TimeoutException e) {
                 log.warn("OPEN API 응답을 요청하는 중 타임아웃이 발생했습니다. 재시도합니다...(" + (retryCount + 1) + "/" + MAX_RETRY_COUNTS + ")");
                 retryCount++;

--- a/src/main/java/com/book/backend/domain/search/service/SearchService.java
+++ b/src/main/java/com/book/backend/domain/search/service/SearchService.java
@@ -40,13 +40,13 @@ public class SearchService {
 
             // 제목으로 검색
             searchRequestDto.setTitle(requestDto.getInput());
-            JSONObject jsonResponse = openAPI.connect(subUrl, searchRequestDto, new SearchResponseDto());
+            JSONObject jsonResponse = openAPI.connect(subUrl, searchRequestDto, new SearchResponseDto(), 1);
             responseList.addAll(responseParser.search(jsonResponse));
 
             // 작가로 검색
             searchRequestDto.setTitle(null);
             searchRequestDto.setAuthor(requestDto.getInput());
-            jsonResponse = openAPI.connect(subUrl, searchRequestDto, new SearchResponseDto());
+            jsonResponse = openAPI.connect(subUrl, searchRequestDto, new SearchResponseDto(), 1);
             responseList.addAll(responseParser.search(jsonResponse));
 
             return duplicateChecker(responseList);
@@ -57,7 +57,7 @@ public class SearchService {
                     .build();
 
             searchRequestDto.setKeyword(requestDto.getInput());
-            JSONObject jsonResponse = openAPI.connect(subUrl, searchRequestDto, new SearchResponseDto());
+            JSONObject jsonResponse = openAPI.connect(subUrl, searchRequestDto, new SearchResponseDto(), 1);
             return responseParser.search(jsonResponse);
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,8 +53,7 @@ spring-doc:
 openapi:
   url: ${OPENAPI_URL}
   authKey: ${OPENAPI_AUTH_KEY}
-  timeoutSeconds: ${OPENAPI_TIMEOUT_SECONDS}
-  maxRetryCounts: ${OPENAPI_MAX_RETRY_COUNTS}
+  maxRetryCounts: 15
 
 kakao:
   publicKeyUri: https://kauth.kakao.com/.well-known/jwks.json


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- [x] #156 


## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- [x] 타임아웃 시간, 최대 재시도 횟수 .env에서 삭제
- [x] 타임아웃 시간 커스텀 가능하게 수정


### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 기존 타임아웃 설정은 각 요청에 적합한 시간이 아닌 일관적으로 여유가 있는 타임아웃 시간(2초)으로 고정되어 있었습니다.
> 그러나 이로 인해 짧은 응답시간을 가지는 Open API 요청에서도 불필요하게 응답을 오래 대기해야 하는 문제가 있었습니다.
>
> 이를 해결하기 위해 **타임아웃 시간을 커스텀 가능**하도록 수정했습니다.
> 이제 짧은 응답시간을 갖는 Open API 요청(ex) 책 정보 조회)에 대해서는 타임아웃 시간이 `1초`, 긴 응답시간을 갖는 Open API 요청(ex) 사이즈가 500이 넘는 책 목록 요청)에 대해서는 `2초`로 설정됩니다.
>
> 또한 추가적으로 **타임아웃 시간 및 최대 재시도 횟수를 .env에서 제거**하고 코드에만 남겨둠으로써 수정에 용이하도록 개선했습니다.